### PR TITLE
Race condition between event handler and state initalization

### DIFF
--- a/src/benlink/controller.py
+++ b/src/benlink/controller.py
@@ -325,12 +325,6 @@ class RadioController:
 
         status = await self._conn.get_status()
 
-        # No need to save the remove event handler function, since we don't
-        # need to unregister it when we disconnect (the connection will take care of that)
-        self._conn.add_event_handler(
-            self._on_event_message
-        )
-
         # For some reason, enabling the HT_STATUS_CHANGED event
         # also enables the DATA_RXD event, and maybe others...
         # need to investigate further.
@@ -346,6 +340,12 @@ class RadioController:
             status=status,
             settings=settings,
             channels=channels,
+        )
+
+        # No need to save the remove event handler function, since we don't
+        # need to unregister it when we disconnect (the connection will take care of that)
+        self._conn.add_event_handler(
+            self._on_event_message
         )
 
     def _on_event_message(self, event_message: EventMessage) -> None:


### PR DESCRIPTION
Getting error [Radio state not initialized. Try calling connect() first](https://github.com/khusmann/benlink/blob/1bdc285135592807e24e140e7b0b722646a652ea/src/benlink/controller.py#L354).  What I think is happening is there's a race condition between when we [add event handlers ](https://github.com/khusmann/benlink/blob/1bdc285135592807e24e140e7b0b722646a652ea/src/benlink/controller.py#L331) and [when we initialize the radio](https://github.com/khusmann/benlink/blob/1bdc285135592807e24e140e7b0b722646a652ea/src/benlink/controller.py#L343).

This PR moves the add event handler after state initialization.