### PR TITLE
Add SET_SATELLITE_INFO (opcode 77) to BasicCommand

### DIFF
--- a/src/benlink/protocol/command/message.py
+++ b/src/benlink/protocol/command/message.py
@@ -132,6 +132,7 @@ class BasicCommand(IntEnum):
     SET_DEV_ID = 74
     GET_PF_ACTIONS = 75
     GET_POSITION = 76
+    SET_SATELLITE_INFO = 77
 
 
 def frame_type_disc(m: Message):


### PR DESCRIPTION
Adds the missing final opcode `SET_SATELLITE_INFO = 77` to `BasicCommand`.

`benlink`'s `BasicCommand` currently matches the official firmware's command table exactly through `GET_POSITION = 76` and stops there. The next (and currently last) opcode is `SET_SATELLITE_INFO = 77`, verified against the official **BTECH UV Programmer** app (`com.benshikj.ht.btech.ham`), whose command enum lists, in ordinal order: `… GET_PF_ACTIONS (75), GET_POSITION (76), SET_SATELLITE_INFO (77)`.

This opcode backs the recent SATCOM / amateur-satellite firmware features (uploading Keplerian elements for satellite tracking). This PR adds the enum entry only, so the opcode decodes by name instead of falling through to `UNKNOWN`; it does **not** add the request/response payload structs (the satellite-info payload isn't reverse-engineered here).
