### PR TITLE
Add SET_SATELLITE_INFO (opcode 77) request + reply body structs

### DIFF
--- a/src/benlink/protocol/command/message.py
+++ b/src/benlink/protocol/command/message.py
@@ -30,6 +30,7 @@ from .bss_settings import (
 from .phone_status import SetPhoneStatusBody, SetPhoneStatusReplyBody
 from .status import GetHtStatusBody, GetHtStatusReplyBody
 from .position import GetPositionBody, GetPositionReplyBody
+from .satellite_info import SetSatelliteInfoBody, SetSatelliteInfoReplyBody
 
 
 class CommandGroup(IntEnum):
@@ -184,6 +185,11 @@ def body_disc(m: Message, n: int):
                     out = GetHtStatusReplyBody if m.is_reply else GetHtStatusBody
                 case BasicCommand.GET_POSITION:
                     out = GetPositionReplyBody if m.is_reply else GetPositionBody
+                case BasicCommand.SET_SATELLITE_INFO:
+                    out = (
+                        SetSatelliteInfoReplyBody if m.is_reply
+                        else SetSatelliteInfoBody
+                    )
                 case _:
                     return bf_bytes(n // 8)
         case CommandGroup.EXTENDED:
@@ -223,6 +229,8 @@ MessageBody = t.Union[
     GetHtStatusReplyBody,
     GetPositionReplyBody,
     GetPositionBody,
+    SetSatelliteInfoBody,
+    SetSatelliteInfoReplyBody,
 ]
 
 

--- a/src/benlink/protocol/command/satellite_info.py
+++ b/src/benlink/protocol/command/satellite_info.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+from .bitfield import Bitfield, bf_int, bf_int_enum, bf_lit_int, bf_str, bf_map
+from .common import ReplyStatus
+import typing as t
+
+
+class CountdownMapper:
+    """16-bit seconds-until-event; 0xFFFF == unknown/none, 0 == now/past."""
+
+    def forward(self, x: int) -> int | None:
+        return x if x != 0xFFFF else None
+
+    def back(self, y: int | None) -> int:
+        return y if y is not None else 0xFFFF
+
+
+class SetSatelliteInfoBody(Bitfield):
+    # Fixed 30-byte payload. Name occupies the first 20 bytes; the firmware
+    # app encodes it as GB2312 (identical to ASCII for names like "ISS",
+    # "AO-91"; diverges only for non-ASCII characters). NUL-padded.
+    name: str = bf_str(20, "gb2312")
+
+    # Azimuth, integer degrees 0-359 (9 bits), then 7 reserved bits.
+    azimuth: int = bf_int(9)
+    _pad_az: t.Literal[0] = bf_lit_int(7, default=0)
+
+    # Elevation, integer degrees (8 bits, written unsigned by the app's
+    # tracking path), then 8 reserved bits.
+    elevation: int = bf_int(8)
+    _pad_el: t.Literal[0] = bf_lit_int(8, default=0)
+
+    # Slant range to the satellite, km (firmware clamps >65535 to 0).
+    range_km: int = bf_int(16)
+
+    # Satellite orbital altitude, km (firmware clamps >65535 to 0).
+    altitude_km: int = bf_int(16)
+
+    # Seconds until the next tracked event; 0xFFFF == unknown.
+    countdown_secs: int | None = bf_map(bf_int(16), CountdownMapper())
+
+
+class SetSatelliteInfoReplyBody(Bitfield):
+    # Inferred from the SET_* convention (bare ReplyStatus ack, like
+    # SetPhoneStatusReplyBody). No dedicated reply parser is present in the
+    # decompile; worth confirming against one on-air capture.
+    reply_status: ReplyStatus = bf_int_enum(ReplyStatus, 8)


### PR DESCRIPTION
Follows up #26 with the `SET_SATELLITE_INFO` (BasicCommand 77) payload structs.

`SET_SATELLITE_INFO` is sent **phone → radio** while the app is tracking an
amateur satellite. It pushes the current pass solution so the HT can show
az/el/range on its own screen during a pass. (Doppler shift is handled
separately via `FREQ_MODE_SET_PAR`, not here.)

### Wire layout (fixed 30 bytes)

| off | size | field | notes |
|---|---|---|---|
| 0 | 20 B | `name` | satellite name, GB2312, NUL-padded |
| 20 | 9 b | `azimuth` | integer degrees 0–359 |
| — | 7 b | reserved (0) | |
| — | 8 b | `elevation` | integer degrees (unsigned) |
| — | 8 b | reserved (0) | |
| 24 | 16 b | `range_km` | slant range, km |
| 26 | 16 b | `altitude_km` | orbital altitude, km |
| 28 | 16 b | `countdown_secs` | seconds to next event; `0xFFFF` = unknown |

Bitfields are MSB-first / big-endian, matching the rest of the protocol.

### Provenance

The fields come from the BTECH UV Programmer app (`com.benshikj.ht.btech.ham`):
the serializer `w4.d#a()` and its caller `com.dw.ht.satellite.b#W()`, which
computes the look-angle vector via Orekit and rounds az/el/range/altitude into
the fields above. Meanings are cross-checked against the app's embedded
`satellite.proto` data model (`RfInfo`/`GP`/TLE).

### Verification

Golden vector — `name="ISS", az=180°, el=45°, range=800 km, alt=420 km,
countdown=600 s`:

```
49 53 53 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
5A 00 2D 00 03 20 01 A4 02 58
```

`SetSatelliteInfoBody(...).to_bytes()` reproduces this byte-for-byte and
round-trips via `from_bytes`. The `countdown_secs` sentinel (`0xFFFF` ↔ `None`)
round-trips, and `SetSatelliteInfoReplyBody` encodes a `ReplyStatus.SUCCESS`
ack to `0x00`.

### Notes

- **Name charset is GB2312** (`bf_str(20, "gb2312")`), not ASCII — identical for
  typical names (`ISS`, `AO-91`, `SO-50`), diverging only on non-ASCII.
- Firmware clamps `range_km`/`altitude_km` > 65535 to **0** (not a sentinel).
- **The reply body is inferred, not captured.** Every `SET_*` command in this
  protocol returns a bare `ReplyStatus` ack (modeled here on
  `SetPhoneStatusReplyBody`), and the decompile contains no dedicated reply
  parser. The request body is the verified contribution; the reply struct can
  be dropped from this PR if confirming it against an on-air BLE/RFCOMM capture
  first is preferable.
